### PR TITLE
Return full error response not a string

### DIFF
--- a/lib/geo.what3words.js
+++ b/lib/geo.what3words.js
@@ -167,7 +167,7 @@ What3Words.prototype.execute = function (method, params) {
         if (response.code !== 200) {
           reject('Unable to connect to the What3Words API endpoint.');
         } else if (response.body.error) {
-          reject(response.body.error + '. Message: ' + response.body.message);
+          reject(response.body);
         }
 
         resolve(response.body);


### PR DESCRIPTION
Returning the error object not a string for processing the failure.